### PR TITLE
修复base64解码问题

### DIFF
--- a/core/node_manager.py
+++ b/core/node_manager.py
@@ -37,7 +37,9 @@ class NodeManager(BaseDataItem):
         url = group.subscribe
         r = requests.get(url)
         list = r.text
-        list = base64.b64decode(list).decode('utf8')
+        lens = len(list)
+        lenx = lens - (lens % 4 if lens % 4 else 4)
+        list = base64.b64decode(list[:lenx]).decode('utf8')
 
         group.nodes.clear()
         for line in list.splitlines():


### PR DESCRIPTION
发现添加订阅时，请求回来的base64字符串若不是4的倍数，会解码失败，导致订阅失败。
解决方法参考[Python解码base64遇到Incorrect padding错误](https://www.cnblogs.com/wswang/p/7717997.html)